### PR TITLE
fix(snap): Add git to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,8 @@ parts:
       - python3-pip
       - python3-poetry
       - python3-venv
+    stage-packages:
+      - git
     override-pull: |
       craftctl default
       if tag=$(git describe --tags --exact-match 2>/dev/null); then


### PR DESCRIPTION
A hard runtime dependency on git was introduced by #43

Fixes #54